### PR TITLE
Show correct error in console when SDK is not loaded

### DIFF
--- a/view/frontend/templates/breadcheckout/view.phtml
+++ b/view/frontend/templates/breadcheckout/view.phtml
@@ -114,7 +114,11 @@
                 let errorInfo = {
                     err: 'err'
                 };
-                document.logBreadIssue('error', errorInfo, 'Instance of Bread Payments SDK does not exist');
+                try {
+                    document.logBreadIssue('error', errorInfo, 'Instance of Bread Payments SDK does not exist');
+                } catch (error) {
+                    console.error('Instance of Bread Payments SDK does not exist');
+                }
             }
         };    
             


### PR DESCRIPTION
For countries where SDK is blocked there is no document.logBreadIssue method. This causes an error. We can handle it and show the correct error in the console.