### PR TITLE
Remove support of old PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "version": "2.4.4",
     "require": {
-        "php": "~7.0.13||~7.1.0||~7.1.3||~7.2.0||~7.3.0||~7.4.0||~8.0.0||~8.1.0||~8.2.0"
+        "php": "~8.1.0||~8.2.0"
     },
     "type": "magento2-module",
     "repositories": [{


### PR DESCRIPTION
I propose removing the support for old PHP versions. Magento 2.0.x-2.4.3-p3 versions are out of support already.